### PR TITLE
Added Templating to Glossary

### DIFF
--- a/resources/glossary.md
+++ b/resources/glossary.md
@@ -37,5 +37,6 @@ directory
 .gitignore
   a file in a git repo that will not add the files that are included in this .gitignore file. Used to prevent files from being unnecessarily committed.
   
-
+templating
+  idea of using code that someone else wrote so that you do not have to rewrite it (for instance, the jupyter book allows us to create a website without working on HTML; does all of the work in the background, all we have to do is provide the HTML).
 ```

--- a/resources/glossary.md
+++ b/resources/glossary.md
@@ -23,13 +23,17 @@ pull (changes from a repository)
   
 repository
   a project folder with tracking information in it in the form of a .git file
-  
 
 shell
   a command line interface; allows for access to an operating system
   
 terminal
   a program that makes shell visible for us and allows for interactions with it
+  
+ROM (Read-Only Memory)
+  Memory that only gets read by the CPU
+  
+
 
 
 ```

--- a/resources/glossary.md
+++ b/resources/glossary.md
@@ -36,8 +36,6 @@ terminal
 ROM (Read-Only Memory)
   Memory that only gets read by the CPU
   
-
-
 directory 
   a collection of files typically created for organizational purposes
 
@@ -45,5 +43,6 @@ directory
   a file in a git repo that will not add the files that are included in this .gitignore file. Used to prevent files from being unnecessarily committed.
   
 templating
-  idea of using code that someone else wrote so that you do not have to rewrite it (for instance, the jupyter book allows us to create a website without working on HTML; does all of the work in the background, all we have to do is provide the HTML).
+  templating is the idea of changing the input or output of a system. For instance, the Jupyter book, instead of outputting the markdown files as markdown files, displays them as HTML pages (with the contents of the markdown file).
+  
 ```


### PR DESCRIPTION
I want to start adding Jupyter Book terms since we will be using it a lot for the rest of the class. Would it make sense to create a new page that is strictly for Jupyter Book help/terms and keep this one as strictly git/github/bash or keep all of the terms onto one page?